### PR TITLE
build on a modern platformio fix

### DIFF
--- a/src/RemoteDebug.cpp
+++ b/src/RemoteDebug.cpp
@@ -430,9 +430,12 @@ void RemoteDebug::handle() {
 		if (TelnetClient && TelnetClient.connected()) {
 
 			// Verify if the IP is same than actual conection
-
+#if ARDUINO_ESP8266_MAJOR >= 3
+			WiFiClient newClient = TelnetServer.accept();
+#else
 			WiFiClient newClient; // @suppress("Abstract class cannot be instantiated")
 			newClient = TelnetServer.available();
+#endif
 			String ip = newClient.remoteIP().toString();
 
 			if (ip == TelnetClient.remoteIP().toString()) {
@@ -455,8 +458,11 @@ void RemoteDebug::handle() {
 		} else {
 
 			// New TCP client
-
+#if ARDUINO_ESP8266_MAJOR >= 3
+			TelnetClient = TelnetServer.accept();
+#else
 			TelnetClient = TelnetServer.available();
+#endif
 
 			// Password request ? - 18/07/18
 
@@ -1788,7 +1794,7 @@ void RemoteDebug::setNoFilter() {
 
 // Silence
 
-void RemoteDebug::silence(boolean activate, boolean showMessage, boolean fromBreak, uint32_t timeout) {
+void RemoteDebug::silence(boolean activate, boolean showMessage, boolean /*fromBreak*/, uint32_t timeout) {
 
 	// Set silence and timeout
 

--- a/src/utility/WebSockets.cpp
+++ b/src/utility/WebSockets.cpp
@@ -24,6 +24,8 @@
 
 #include "WebSockets.h"
 
+#ifndef WEBSOCKET_DISABLED
+
 #ifdef ESP8266
 #include <core_esp8266_features.h>
 #endif
@@ -652,3 +654,5 @@ size_t WebSockets::write(WSclient_t * client, const char *out) {
 	if(out == NULL) return 0;
 	return write(client, (uint8_t*)out, strlen(out));
 }
+
+#endif /* WEBSOCKET_DISABLED */

--- a/src/utility/WebSockets.h
+++ b/src/utility/WebSockets.h
@@ -25,6 +25,8 @@
 #ifndef WEBSOCKETS_H_
 #define WEBSOCKETS_H_
 
+#ifndef WEBSOCKET_DISABLED
+
 #ifdef STM32_DEVICE
 #include <application.h>
 #define bit(b) (1UL << (b)) // Taken directly from Arduino.h
@@ -309,4 +311,5 @@ class WebSockets {
 #ifndef UNUSED
 #define UNUSED(var) (void)(var)
 #endif
+#endif /* WEBSOCKET_DISABLED */
 #endif /* WEBSOCKETS_H_ */

--- a/src/utility/WebSocketsClient.cpp
+++ b/src/utility/WebSocketsClient.cpp
@@ -703,7 +703,12 @@ void WebSocketsClient::connectedCb() {
     _client.tcp->setNoDelay(true);
 
     if(_client.isSSL && _fingerprint.length()) {
-        if(!_client.ssl->verify(_fingerprint.c_str(), _host.c_str())) {
+#if ARDUINO_ESP8266_MAJOR >= 3
+        if(!_client.ssl->setFingerprint(_fingerprint.c_str()))
+#else
+        if(!_client.ssl->verify(_fingerprint.c_str(), _host.c_str()))
+#endif
+        {
             DEBUG_WEBSOCKETS("[WS-Client] certificate mismatch\n");
             WebSockets::clientDisconnect(&_client, 1000);
             return;

--- a/src/utility/WebSocketsClient.cpp
+++ b/src/utility/WebSocketsClient.cpp
@@ -25,6 +25,8 @@
 #include "WebSockets.h"
 #include "WebSocketsClient.h"
 
+#ifndef WEBSOCKET_DISABLED
+
 WebSocketsClient::WebSocketsClient() {
     _cbEvent = NULL;
     _client.num = 0;
@@ -759,5 +761,5 @@ void WebSocketsClient::asyncConnect() {
     }
 
 }
-
+#endif /* WEBSOCKET_DISABLED */
 #endif

--- a/src/utility/WebSocketsClient.h
+++ b/src/utility/WebSocketsClient.h
@@ -27,6 +27,7 @@
 
 #include "WebSockets.h"
 
+#ifndef WEBSOCKET_DISABLED
 class WebSocketsClient: private WebSockets {
     public:
 #ifdef __AVR__
@@ -132,5 +133,5 @@ class WebSocketsClient: private WebSockets {
         }
 
 };
-
+#endif /* WEBSOCKET_DISABLED */
 #endif /* WEBSOCKETSCLIENT_H_ */

--- a/src/utility/WebSocketsServer.cpp
+++ b/src/utility/WebSocketsServer.cpp
@@ -25,6 +25,8 @@
 #include "WebSockets.h"
 #include "WebSocketsServer.h"
 
+#ifndef WEBSOCKET_DISABLED
+
 WebSocketsServer::WebSocketsServer(uint16_t port, String origin, String protocol) {
     _port = port;
     _origin = origin;
@@ -869,5 +871,4 @@ void WebSocketsServer::handleHeader(WSclient_t * client, String * headerLine) {
     }
 }
 
-
-
+#endif /* WEBSOCKET_DISABLED */

--- a/src/utility/WebSocketsServer.h
+++ b/src/utility/WebSocketsServer.h
@@ -25,6 +25,8 @@
 #ifndef WEBSOCKETSSERVER_H_
 #define WEBSOCKETSSERVER_H_
 
+#ifndef WEBSOCKET_DISABLED
+
 #include "WebSockets.h"
 
 #ifndef WEBSOCKETS_SERVER_CLIENT_MAX
@@ -207,6 +209,5 @@ private:
 
 };
 
-
-
+#endif /* WEBSOCKET_DISABLED */
 #endif /* WEBSOCKETSSERVER_H_ */

--- a/src/utility/libb64/cdecode.c
+++ b/src/utility/libb64/cdecode.c
@@ -5,6 +5,8 @@ This is part of the libb64 project, and has been placed in the public domain.
 For details, see http://sourceforge.net/projects/libb64
 */
 
+#ifndef WEBSOCKET_DISABLED
+
 #ifdef ESP8266
 #include <core_esp8266_features.h>
 #endif
@@ -96,3 +98,5 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
 }
 
 #endif
+
+#endif /* WEBSOCKET_DISABLED */

--- a/src/utility/libb64/cdecode_inc.h
+++ b/src/utility/libb64/cdecode_inc.h
@@ -8,6 +8,8 @@ For details, see http://sourceforge.net/projects/libb64
 #ifndef BASE64_CDECODE_H
 #define BASE64_CDECODE_H
 
+#ifndef WEBSOCKET_DISABLED
+
 typedef enum
 {
 	step_a, step_b, step_c, step_d
@@ -24,5 +26,7 @@ void base64_init_decodestate(base64_decodestate* state_in);
 int base64_decode_value(char value_in);
 
 int base64_decode_block(const char* code_in, const int length_in, char* plaintext_out, base64_decodestate* state_in);
+
+#endif /* WEBSOCKET_DISABLED */
 
 #endif /* BASE64_CDECODE_H */

--- a/src/utility/libb64/cencode.c
+++ b/src/utility/libb64/cencode.c
@@ -5,6 +5,8 @@ This is part of the libb64 project, and has been placed in the public domain.
 For details, see http://sourceforge.net/projects/libb64
 */
 
+#ifndef WEBSOCKET_DISABLED
+
 #ifdef ESP8266
 #include <core_esp8266_features.h>
 #endif
@@ -117,3 +119,5 @@ int base64_encode_blockend(char* code_out, base64_encodestate* state_in)
 }
 
 #endif
+
+#endif /* WEBSOCKET_DISABLED */

--- a/src/utility/libb64/cencode_inc.h
+++ b/src/utility/libb64/cencode_inc.h
@@ -8,6 +8,8 @@ For details, see http://sourceforge.net/projects/libb64
 #ifndef BASE64_CENCODE_H
 #define BASE64_CENCODE_H
 
+#ifndef WEBSOCKET_DISABLED
+
 typedef enum
 {
 	step_A, step_B, step_C
@@ -27,5 +29,7 @@ char base64_encode_value(char value_in);
 int base64_encode_block(const char* plaintext_in, int length_in, char* code_out, base64_encodestate* state_in);
 
 int base64_encode_blockend(char* code_out, base64_encodestate* state_in);
+
+#endif /* WEBSOCKET_DISABLED */
 
 #endif /* BASE64_CENCODE_H */


### PR DESCRIPTION
ESP board library >= 3.0.0 removed WiFiClientSecure::verify and also deprecated WiFiClient::available thus breaking and clogging the build.

Also further propagated WEBSOCKET_DISABLE define handling further into src/utilitiy to not build unnecessary modules.